### PR TITLE
Align crypt() and encrypt() in unistd.h to crypt.h

### DIFF
--- a/src/emx/include/unistd.h
+++ b/src/emx/include/unistd.h
@@ -443,9 +443,9 @@ int	 symlink(const char * __restrict, const char * __restrict);
 
 /* X/Open System Interfaces */
 #if __XSI_VISIBLE
-char	*crypt(const char *, const char *);
+//char	*crypt(const char *, const char *);
 /** @todo char	*ctermid(char *); */		/* XXX ??? */
-void	 encrypt(char *, int);                  /* bird: SuS say it returns void, and so does our implementation */
+//void	 encrypt(char *, int);                  /* bird: SuS say it returns void, and so does our implementation */
 int	 fchdir(int);
 /* tcpip: long	 gethostid(void); */
 pid_t	 getpgid(pid_t _pid);       /* bird: SuS say pid_r return. */


### PR DESCRIPTION
remove crypt() and encrypt() from unistd.h, as they are defined in crypt.h. This might give a clash if both .h are included